### PR TITLE
Added GALAXY_SLOTS built-in to runThreadN option.

### DIFF
--- a/star.xml
+++ b/star.xml
@@ -15,7 +15,7 @@
     #if $refGenomeSource.genomeSource == "history":
     star.py genomeGenerate
     --limitGenomeGenerateRAM 31000000000
-    --runThreadN 8
+    --runThreadN \${GALAXY_SLOTS:-4}
     --genomeDir './'
     --genomeFastaFiles $refGenomeSource.genomeFasta
     --sjdbGTFfile $refGenomeSource.gtfFile
@@ -39,7 +39,7 @@
     ## Defaults (partial list)
     --quantMode "GeneCounts"
     --genomeLoad "NoSharedMemory"
-    --runThreadN 8
+    --runThreadN \${GALAXY_SLOTS:-4}
     --outSAMtype "BAM SortedByCoordinate"
     --twopassMode "Basic"
     --outFileNamePrefix "./"


### PR DESCRIPTION
Instead of specifying a hard-coded default value, you can specify the GALAXY_SLOTS option and Galaxy will take care of the rest.
